### PR TITLE
Features/automatic keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,35 @@ mexico:
   id: 3
   name: Mexico
 ```
+
+### Automatic Key Attribute
+
+When using the hash format for your YAML file, ActiveYaml will automatically add a `key` attribute with the name of the object.  You can overwrite this by setting the key attribute in the YAML file.
+For example:
+```
+au:
+  id: 1
+  name: Australia
+```
+
+When you access the object you can do `Country.find(1).key => 'au'`. Or `Country.find_by_key('au')`
+
+If you want a different key on only some objects you can mix and match:
+
+```
+au:
+  id: 1
+  key: aus
+  name: Australia
+nz:
+  id: 2
+  name: New Zealand
+```
+
+`Country.find(1).key => 'aus'`
+
+`Country.find(2).key => 'nz'`
+
 ### Multiple files per model
 
 You can use multiple files to store your data. You will have to choose between hash or array style as you cannot use both for one model.

--- a/lib/active_yaml/base.rb
+++ b/lib/active_yaml/base.rb
@@ -9,7 +9,7 @@ module ActiveYaml
         if (data = raw_data).is_a?(Array)
           data
         elsif data.respond_to?(:values)
-          data.values
+          data.map{ |key, value| {"key" => key}.merge(value) }
         end
       end
 

--- a/spec/active_yaml/aliases_spec.rb
+++ b/spec/active_yaml/aliases_spec.rb
@@ -68,7 +68,7 @@ describe ActiveYaml::Aliases do
 
       it 'excludes them from fields' do
         model.all
-        expect(model.field_names).to match_array [:name, :flavor, :price, :slogan]
+        expect(model.field_names).to match_array [:name, :flavor, :price, :slogan, :key]
       end
     end
   end

--- a/spec/active_yaml/base_spec.rb
+++ b/spec/active_yaml/base_spec.rb
@@ -94,9 +94,21 @@ describe ActiveYaml::Base do
     describe "with hash data" do
       it "returns an array of hashes" do
         expect(City.load_file).to be_kind_of(Array)
-        expect(City.load_file).to include({"state" => :new_york, "name" => "Albany", "id" => 1})
+        expect(City.load_file).to include({"state" => :new_york, "name" => "Albany", "id" => 1, "key" => "albany"})
         City.reload
         expect(City.all).to include(City.new(:id => 1))
+      end
+
+      it "automatically adds the key attribute" do
+        expect(City.load_file.first.keys).to include("key")
+      end
+
+      it "doesn't overwrite the key attribute when specifically listed in the yml file" do
+        expect(City.load_file.last["key"]).to eql("livable")
+      end
+
+      it "uses the root key of the hash if no key attribute is specified" do
+        expect(City.load_file.first["key"]).to eql("albany")
       end
     end
 

--- a/spec/fixtures/cities.yml
+++ b/spec/fixtures/cities.yml
@@ -6,3 +6,8 @@ portland:
   id: 2
   state: Oregon
   name: Portland
+melbourne:
+  id: 3
+  state: Vic
+  name: Melbourne
+  key: livable


### PR DESCRIPTION
Set a default key attribute when loading ActiveYaml files
* When loading a yml file in hash format, we take the root key of the
  hash and set it as a `key` attribute on the object.
* If a key attribute is specified in the yml file, make sure we
  don't overwrite it with this new default.
* This change eliminates some duplication in yml files where it is
  common to have some sort of key or name attribute that is the same
  as the original key from the yml file's hash.

For example

```
default:
  key: default
  id: 1
```

would now simply be:

```
default:
  id: 1
```